### PR TITLE
Typos et autres corrections, ajout de liens, cohérence

### DIFF
--- a/Guidelines-Accessibilite.md
+++ b/Guidelines-Accessibilite.md
@@ -4,7 +4,7 @@ _Bonnes pratiques accessibilité en production_
 
 ## Généralités
 
-* Ne pas fixer de hauteur sur les éléments afin que le contenu reste lisible lorsque le texte est zoomé.
+* Ne pas fixer de hauteur sur les éléments afin que le contenu reste lisible lorsque le texte est zoomé
 * Respecter la hiérarchie des titres `<hX>`
 * Ne pas supprimer l’*outline* autour des éléments cliquables (pas de `outline: none`)
 * Utiliser les éléments HTML pour leur fonction/sémantique et non pas pour leur forme
@@ -69,7 +69,7 @@ Ne sont pas concernés :
 
 * Le fil d’ariane
 * Les systèmes de pagination
-* table des matières
+* Table des matières
 
 Plus d’informations : [http://www.accede-web.com/notices/html-css-javascript/1-structure/1-5-role-navigation/](http://www.accede-web.com/notices/html-css-javascript/1-structure/1-5-role-navigation/)
 
@@ -81,7 +81,7 @@ On peut générer du contenu en CSS à l’aide de `::before` et `::after` et la
 
 Mais la plupart des lecteurs d’écrans actuels peuvent retranscrire ce contenu, ce qui peut provoquer une gêne (voir [http://tink.uk/accessibility-support-for-css-generated-content/](http://tink.uk/accessibility-support-for-css-generated-content/)).
 
-Pour éviter cela, il est préférable d’insérer l’attribut `aria-hidden=true` sur l’élément.
+Pour éviter cela, il est préférable d’insérer l’attribut `aria-hidden="true"` sur l’élément.
 
 Exemple :
 
@@ -163,7 +163,7 @@ Ne pas faire :
   background-image: url("facebook.png");
 }
 ```
-→ dans ce cas là, le lecteur d’écran retranscrit l’intégralité de l’URL.
+→ dans ce cas-là, le lecteur d’écran retranscrit l’intégralité de l’URL.
 
 Même en ajoutant un attribut `title="Retrouvez-nous sur Facebook"` sur le lien, celui-ci reste considéré comme vide.
 De plus, il n’est pas sûr à 100% que l’attribut `title` soit correctement restitué par le lecteur d’écran (tout dépend de la configuration de l’utilisateur).
@@ -184,7 +184,7 @@ De plus, il n’est pas sûr à 100% que l’attribut `title` soit correctement 
   background-image: url("facebook.png");
 }
 ```
-→ dans ce cas là, le lecteur d’écran retranscrit bien _"Retrouvez-nous sur Facebook"_.
+→ dans ce cas-là, le lecteur d’écran retranscrit bien _"Retrouvez-nous sur Facebook"_.
 
 ### Ouverture dans une nouvelle fenêtre
 
@@ -282,9 +282,9 @@ Label/input
 
 **TODO**
 
-Player accessibles
+Players accessibles
 
-Sous-titres avec webVTT
+Sous-titres avec WebVTT
 
 ## Design
 
@@ -302,7 +302,7 @@ Sous-titres avec webVTT
 
 **TODO**
 
-Ajax et ARIA live
+AJAX et ARIA live
 
 ### Composants JS
 
@@ -316,7 +316,7 @@ ARIA
 
 ## Ressources
 
-* Notices Accedeweb [http://www.accede-web.com/notices/](http://www.accede-web.com/notices/)
+* Notices Accède Web [http://www.accede-web.com/notices/](http://www.accede-web.com/notices/)
 * Patterns accessibles [http://a11yproject.com/patterns/](http://a11yproject.com/patterns/)
 * Exemples ARIA [http://heydonworks.com/practical_aria_examples/](http://heydonworks.com/practical_aria_examples/)
 * RGAA 3 [https://references.modernisation.gouv.fr/rgaa-accessibilite](https://references.modernisation.gouv.fr/rgaa-accessibilite)

--- a/Guidelines-CSS.md
+++ b/Guidelines-CSS.md
@@ -29,7 +29,7 @@ Documentation : [http://www.nicoespeon.com/fr/2013/05/plongee-au-coeur-de-oocss/
 
 Un "reset" CSS permettant d’harmoniser les styles par défaut des navigateurs est systématiquement appliqué en début de projet.
 
-Normalize.css est recommandé. Il s’agit d’un célèbre reset CSS employé par Twitter, Github, Bootstrap, Guardian, KNACSS, etc.
+Normalize.css est recommandé. Il s’agit d’un célèbre reset CSS employé par Twitter, GitHub, Bootstrap, Guardian, KNACSS, etc.
 
 Documentation : [http://necolas.github.io/normalize.css/](http://necolas.github.io/normalize.css/)
 
@@ -94,7 +94,7 @@ En dernier ressort, employer la ressource [Browserhacks](http://browserhacks.com
 
 ## Commentaires
 
-Usage de mots-clés informatifs au sein de commentaires importants sont appréciés, sous la forme :
+Usage de mots-clés informatifs au sein de commentaires importants est apprécié, sous la forme :
 
 * `@TODO` → point à finir / corriger avant de livrer
 * `@BUGFIX` → explication d’une correction de bug
@@ -112,7 +112,7 @@ Ainsi, il est indiqué de pouvoir cibler n’importe quel élément indépendamm
 De manière générale :
 
 * **Il est préférable de cibler les éléments à l’aide de leur classe HTML** qui pourrait être utilisée dans n’importe quel contexte, par exemple `.title-primary`,
-* **Les sélecteurs  #id doivent être évités en CSS** car trop spécifiques dans le calcul du poids. Si un id doit être ciblé, préférer un sélecteur d’attribut, par exemple `[id=header]`,
+* **Les sélecteurs  #id doivent être évités en CSS** car trop spécifiques dans le calcul du poids. Si un id doit être ciblé, préférer un sélecteur d’attribut, par exemple `[id="header"]`,
 * **Les sélecteurs en cascade ou hyper-structurel doivent être évités** de manière générale (ex: `ul.header li .info` ou `h1 + p + p`),
 * La règle `!important` doit être éradiquée si possible du fait de son poids extrêmement important (certaines parties des styles peuvent toutefois exceptionnellement employer à juste titre `!important`).
 
@@ -151,7 +151,7 @@ Opter pour le modèle de boîte CSS3 (`box-sizing: border-box`) en début de la 
 }
 ```
 
-ou bien :
+ou mieux :
 
 ```
 html {
@@ -561,7 +561,7 @@ Documentation : [https://github.com/bendc/frontend-guidelines#units](https://git
 
 ### Animations gourmandes
 
-* Toujours préciser quelle(s) propriété(s) doit être animée dans transition ou animation
+* Toujours préciser quelle(s) propriété(s) doi(ven)t être animée(s) dans transition ou animation
 * Éviter d’animer des propriétés autres que **transform** ou **opacity** ou **filter** (ou alors ajouter la
 propriété `will-change` et/ou le hack de `translateZ()`.) Source : [https://tzi.github.io/presentation-CSS-perfs/](https://tzi.github.io/presentation-CSS-perfs/)
 
@@ -680,7 +680,7 @@ Documentation : [http://sass-lang.com/](http://sass-lang.com/)
 
 Pour éviter les intervalles qui se chevauchent, ou des Media Queries trop variés, la convention pour définir la valeur d’un Breakpoint est systématiquement :
 
-* **(min-width: ($breakpoint + 1))**** **
+* **(min-width: ($breakpoint + 1))**
 * **(max-width: $breakpoint)**
 
 Exemple avec les variables de Breakpoints suivantes :
@@ -795,7 +795,7 @@ Autant que possible, privilégier le chargement de polices légères et respectu
 
 Alsacréations partage une collection de fontes adaptées et optimisées pour le web : [https://github.com/alsacreations/webfonts](https://github.com/alsacreations/webfonts)
 
-Il est conseillé de récupérer les fontes sur ce repo Github si cela est possible.
+Il est conseillé de récupérer les fontes sur ce repo GitHub si cela est possible.
 
 Le format WOFF2 (Web Open Font Format 2) est privilégié dans tous les cas de figure, pour sa compatibilité et sa légèreté. En second lieu, utiliser WOFF.
 
@@ -825,9 +825,9 @@ Voici un exemple de chargement de police conseillé (IE9 minimum) :
 Le remplissage par du contenu temporaire peut faire appel à *Lorem Ipsum*.
 
 * Pour le texte :
-    * [http://schnaps.it/](http://schnaps.it/)
-    * [http://loripsum.net/](http://loripsum.net/)
-    * [http://chuckipsum.com/](http://chuckipsum.com/)
+    * [http://schnaps.it](http://schnaps.it/)
+    * [http://loripsum.net](http://loripsum.net/)
+    * [http://chuckipsum.com](http://chuckipsum.com/)
 * Pour les images :
-    * [http://placekitten.com/](http://placekitten.com/)
-    * [http://flickholdr.com/](http://flickholdr.com/)
+    * [http://placekitten.com](http://placekitten.com/)
+    * [http://flickholdr.com](http://flickholdr.com/)

--- a/Guidelines-CSS.md
+++ b/Guidelines-CSS.md
@@ -5,15 +5,15 @@ _Bonnes pratiques CSS (et SCSS)  en production_
 
 ## Généralités
 
-* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM).
+* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM)
 * Les indentations se font à l’aide de deux espaces et sous forme de tabulations.
-Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/).
-* Le code CSS produit doit être propre, optimisé et (autant que faire se peut) valide selon les normes (http://jigsaw.w3.org/css-validator/).
-* La feuille de style CSS est de préférence unique et minifiée et appelée à l'aide d'un élément `<link>` dans la section `<head>`. Pas de `@import` dans un fichier CSS.
+Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/)
+* Le code CSS produit doit être propre, optimisé et (autant que faire se peut) valide selon les normes (http://jigsaw.w3.org/css-validator/)
+* La feuille de style CSS est de préférence unique et minifiée et appelée à l'aide d'un élément `<link>` dans la section `<head>`. Pas de `@import` dans un fichier CSS
 * Privilégier tant que possible les syntaxes via propriétés raccourcies : `margin`, `padding`, `font`, `border`, `background`, `border-radius`
-* Utiliser toujours le même type de guillemets. De préférence des doubles guillemets, exemple : `content: ""`;
+* Utiliser toujours le même type de guillemets. De préférence des doubles guillemets, exemple : `content: ""`
 * Utiliser toujours des guillemets pour les valeurs dans les sélecteurs, exemple : `input[type="checkbox"]`
-* Éviter de spécifier les unités pour les valeurs nulles ainsi que pour les hauteurs de lignes, exemple : `margin: 0; line-height: 1.5`.
+* Éviter de spécifier les unités pour les valeurs nulles ainsi que pour les hauteurs de lignes, exemple : `margin: 0; line-height: 1.5`
 
 ## Patterns visuels (OOCSS)
 
@@ -29,7 +29,7 @@ Documentation : [http://www.nicoespeon.com/fr/2013/05/plongee-au-coeur-de-oocss/
 
 Un "reset" CSS permettant d’harmoniser les styles par défaut des navigateurs est systématiquement appliqué en début de projet.
 
-Normalize.css est recommandé. Il s’agit d’un célèbre reset CSS employé par Twitter, GitHub, Bootstrap, Guardian, KNACSS, etc.
+[Normalize.css](https://necolas.github.io/normalize.css/) est recommandé. Il s’agit d’un célèbre reset CSS employé par Twitter, GitHub, Bootstrap, Guardian, KNACSS, etc.
 
 Documentation : [http://necolas.github.io/normalize.css/](http://necolas.github.io/normalize.css/)
 
@@ -69,7 +69,7 @@ selecteur {
 }
 ```
 
-**_Note : l’outil "CSScomb" permet de réordonner automatiquement les déclarations CSS. Il peut être utilisé sous forme de plugin (Atom, Brackets, Sublime text) ou intégré à un Workflow sous forme de tâche Gulp ou Grunt : [http://csscomb.com/](http://csscomb.com/)_**
+**_Note : l’outil "CSScomb" permet de réordonner automatiquement les déclarations CSS. Il peut être utilisé sous forme de plugin (Atom, Brackets, Sublime text) ou intégré à un Workflow sous forme de tâche Gulp ou Grunt : [http://csscomb.com](http://csscomb.com)_**
 
 ## Préfixes navigateurs
 
@@ -82,7 +82,7 @@ Exemple :
 * `-ms-propriété`
 * `propriété`
 
-**_Note : l’outil "Autoprefixer" permet de préfixer automatiquement les propriétés CSS. Il peut être utilisé sous forme de plugin (Atom, Brackets, Sublime text) ou intégré à un Workflow sous forme de tâche Gulp ou Grunt : [https://autoprefixer.github.io/](https://autoprefixer.github.io/)_**
+**_Note : l’outil "Autoprefixer" permet de préfixer automatiquement les propriétés CSS. Il peut être utilisé sous forme de plugin (Atom, Brackets, Sublime Text) ou intégré à un Workflow sous forme de tâche Gulp ou Grunt : [https://autoprefixer.github.io/](https://autoprefixer.github.io/)_**
 
 ## Hacks navigateurs
 
@@ -94,7 +94,7 @@ En dernier ressort, employer la ressource [Browserhacks](http://browserhacks.com
 
 ## Commentaires
 
-Usage de mots-clés informatifs au sein de commentaires importants est apprécié, sous la forme :
+L'usage de mots-clés informatifs au sein de commentaires importants est apprécié, sous la forme :
 
 * `@TODO` → point à finir / corriger avant de livrer
 * `@BUGFIX` → explication d’une correction de bug
@@ -111,10 +111,10 @@ Ainsi, il est indiqué de pouvoir cibler n’importe quel élément indépendamm
 
 De manière générale :
 
-* **Il est préférable de cibler les éléments à l’aide de leur classe HTML** qui pourrait être utilisée dans n’importe quel contexte, par exemple `.title-primary`,
-* **Les sélecteurs  #id doivent être évités en CSS** car trop spécifiques dans le calcul du poids. Si un id doit être ciblé, préférer un sélecteur d’attribut, par exemple `[id="header"]`,
-* **Les sélecteurs en cascade ou hyper-structurel doivent être évités** de manière générale (ex: `ul.header li .info` ou `h1 + p + p`),
-* La règle `!important` doit être éradiquée si possible du fait de son poids extrêmement important (certaines parties des styles peuvent toutefois exceptionnellement employer à juste titre `!important`).
+* **Il est préférable de cibler les éléments à l’aide de leur classe HTML** qui pourrait être utilisée dans n’importe quel contexte, par exemple `.title-primary`
+* **Les sélecteurs  #id doivent être évités en CSS** car trop spécifiques dans le calcul du poids. Si un id doit être ciblé, préférer un sélecteur d’attribut, par exemple `[id="header"]`
+* **Les sélecteurs en cascade ou hyper-structurels doivent être évités** de manière générale (ex: `ul.header li .info` ou `h1 + p + p`)
+* La règle `!important` doit être éradiquée si possible du fait de son poids extrêmement important (certaines parties des styles peuvent toutefois exceptionnellement employer à juste titre `!important`)
 
 ## Taille des polices
 
@@ -310,7 +310,7 @@ input[type="submit"] {
 }
 ```
 
-Documentation : [http://cssspecificity.com/](http://cssspecificity.com/)
+Documentation : [http://cssspecificity.com](http://cssspecificity.com)
 
 ### Sélecteur #id
 
@@ -597,7 +597,8 @@ Documentation : [https://csstriggers.com/](https://csstriggers.com/)
 
 ### `@font-face`
 
-N’imposez pas de chargements aux anciens navigateurs (IE8). Privilégiez `.woff2`.
+* N’imposez pas de chargements aux anciens navigateurs (IE8)
+* Privilégiez `.woff2`
 
 **Non :**
 
@@ -674,7 +675,7 @@ p {
 ```
 
 
-Documentation : [http://sass-lang.com/](http://sass-lang.com/)
+Documentation : [http://sass-lang.com](http://sass-lang.com)
 
 ### Media Queries
 
@@ -712,8 +713,8 @@ $large-screen: 1199px;
 
 ### Préfixes navigateurs
 
-* Automatiser la gestion des préfixes à l’aide de Autoprefixer, ne pas le faire à la main
-* Ne pas utiliser un mixin Sass/LESS pour cette tâche.
+* Automatiser la gestion des préfixes à l’aide d'Autoprefixer, ne pas le faire à la main
+* Ne pas utiliser un mixin Sass/LESS pour cette tâche
 
 **Non (mixin Sass) :**
 
@@ -795,7 +796,7 @@ Autant que possible, privilégier le chargement de polices légères et respectu
 
 Alsacréations partage une collection de fontes adaptées et optimisées pour le web : [https://github.com/alsacreations/webfonts](https://github.com/alsacreations/webfonts)
 
-Il est conseillé de récupérer les fontes sur ce repo GitHub si cela est possible.
+Il est conseillé de récupérer les fontes sur ce dépôt GitHub si cela est possible.
 
 Le format WOFF2 (Web Open Font Format 2) est privilégié dans tous les cas de figure, pour sa compatibilité et sa légèreté. En second lieu, utiliser WOFF.
 
@@ -825,9 +826,9 @@ Voici un exemple de chargement de police conseillé (IE9 minimum) :
 Le remplissage par du contenu temporaire peut faire appel à *Lorem Ipsum*.
 
 * Pour le texte :
-    * [http://schnaps.it](http://schnaps.it/)
-    * [http://loripsum.net](http://loripsum.net/)
-    * [http://chuckipsum.com](http://chuckipsum.com/)
+    * [http://schnaps.it](http://schnaps.it)
+    * [http://loripsum.net](http://loripsum.net)
+    * [http://chuckipsum.com](http://chuckipsum.com)
 * Pour les images :
-    * [http://placekitten.com](http://placekitten.com/)
-    * [http://flickholdr.com](http://flickholdr.com/)
+    * [http://placekitten.com](http://placekitten.com)
+    * [http://flickholdr.com](http://flickholdr.com)

--- a/Guidelines-Developpement-PHP.md
+++ b/Guidelines-Developpement-PHP.md
@@ -6,9 +6,9 @@
 
 ## Généralités
 
-* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM).
+* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM)
 * Les indentations se font à l’aide de deux espaces et sous forme de tabulations.
-Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/).
+Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/)
 * La numérotation des versions suit [Semantic Versioning](http://semver.org/)
 
 ## Garder à l’esprit
@@ -19,7 +19,7 @@ Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig]
 
 Conventions générales :
 
-* [http://www.phptherightway.com/](http://www.phptherightway.com/)
+* [http://www.phptherightway.com](http://www.phptherightway.com)
 * [http://www.php-fig.org/psr/](http://www.php-fig.org/psr/) (de 1 à ?, en anglais a priori)
 * [http://www.php-fig.org/psr/psr-0/fr/](http://www.php-fig.org/psr/psr-0/fr/) : Autoloading Standard
 * [http://www.php-fig.org/psr/psr-1/fr/](http://www.php-fig.org/psr/psr-1/fr/) : Basic Coding Standard
@@ -147,14 +147,14 @@ LIMIT 5, 100");
 
 Quelques critères essentiels sont à observer (parmi d’autres, la liste est non exhaustive) :
 
-* Utiliser les fonctions d’échappement pour valider les données utlisateur, avant traitement ou insertion dans la base de données.
+* Utiliser les fonctions d’échappement pour valider les données utlisateur, avant traitement ou insertion dans la base de données :
     * [mysql_real_escape_string](http://php.net/manual/fr/function.mysql-real-escape-string.php) pour les chaînes passées à la base MySQL
     * [preg_quote](http://php.net/manual/fr/function.preg-quote.php) pour les expressions régulières
     * Utiliser les fonctions de PDO quand c’est possible pour [échapper](http://www.php.net/manual/fr/pdostatement.bindparam.php) ou [préparer une requête](http://www.php.net/manual/fr/pdo.prepare.php)
-* Vérifier toutes les variables trouvées dans `$_REQUEST`, `$_POST`, `$_GET` et `$_COOKIE` avant usage.
-* Désactiver la directive de configuration `magic_quotes` (par défaut).
-* Exploiter au minimum les fichiers et les chemins d’accès au filesystem, ainsi que les fonctions d’exécution de code (`eval`, `system`, `exec`, etc).
-* Utiliser un framework tel que CodeIgniter qui sécurise par défaut quantité d’actions.
+* Vérifier toutes les variables trouvées dans `$_REQUEST`, `$_POST`, `$_GET` et `$_COOKIE` avant usage
+* Désactiver la directive de configuration `magic_quotes` (par défaut)
+* Exploiter au minimum les fichiers et les chemins d’accès au filesystem, ainsi que les fonctions d’exécution de code (`eval`, `system`, `exec`, etc)
+* Utiliser un framework tel que CodeIgniter qui sécurise par défaut quantité d’actions
 
 ## MySQL
 
@@ -220,8 +220,8 @@ user_status
 
 Afin d’améliorer la performance :
 
-* Des index doivent être placés sur les champs servant dans les requêtes SELECT.
-* Dans le cas de jointures, les champs mis en relation (d’une table à l’autre) doivent être de même type (par exemple `INT` avec `INT` et non `INT` avec `MEDIUMINT`).
+* Des index doivent être placés sur les champs servant dans les requêtes SELECT
+* Dans le cas de jointures, les champs mis en relation (d’une table à l’autre) doivent être de même type (par exemple `INT` avec `INT` et non `INT` avec `MEDIUMINT`)
 
 ## Serveur et performance
 

--- a/Guidelines-HTML.md
+++ b/Guidelines-HTML.md
@@ -4,16 +4,16 @@
 
 ## Généralités
 
-* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM),
-* Les indentations se font à l’aide de deux espaces et non à l'aide de tabulations. Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/),
-* Les liens absolus ne doivent pas faire apparaître le protocole (par exemple href="//www.alsacreations.fr/" et non href="http://www.alsacreations.fr"),
-* Choisir des noms en anglais prioritairement (classes, fichiers, images, etc.),
-* Séparer les noms des fichiers, des images des classes et id CSS par des tirets (`.slide-info`, `styles-ie.css`, `jquery-2.0.min.css`, etc), sauf convention contraire apportée par le client,
-* Les noms d'éléments et des attributs sont rédigés en minuscules,
-* Les éléments sont imbriqués correctement,
-* Les éléments sont fermés à l'aide de la balise correspondante (exception pour éléments auto-fermants HTML5 : pas de `/>`),
-* Les valeurs identiques aux attributs ne sont pas renseignées sauf nécessité (ex. en HTML5 pas de `checked="checked"`),
-* L'usage des double quotes est préconisé autour des valeurs d’attributs (ex. `class="fruit"`) ainsi que les simples quotes dans les autres langages JavaScript, PHP (ex. `alert('blup');`) de manière à faciliter les imbrications (ex. `alert('<p class="fruit">plop</p>');`).
+* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM)
+* Les indentations se font à l’aide de deux espaces et non à l'aide de tabulations. Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/)
+* Les liens absolus ne doivent pas faire apparaître le protocole (par exemple href="//www.alsacreations.fr/" et non href="http://www.alsacreations.fr")
+* Choisir des noms en anglais prioritairement (classes, fichiers, images, etc.)
+* Séparer les noms des fichiers, des images des classes et id CSS par des tirets (`.slide-info`, `styles-ie.css`, `jquery-2.0.min.css`, etc), sauf convention contraire apportée par le client
+* Les noms d'éléments et des attributs sont rédigés en minuscules
+* Les éléments sont imbriqués correctement
+* Les éléments sont fermés à l'aide de la balise correspondante (exception pour éléments auto-fermants HTML5 : pas de `/>`)
+* Les valeurs identiques aux attributs ne sont pas renseignées sauf nécessité (ex. en HTML5 pas de `checked="checked"`)
+* L'usage des double quotes est préconisé autour des valeurs d’attributs (ex. `class="fruit"`) ainsi que les simples quotes dans les autres langages JavaScript, PHP (ex. `alert('blup');`) de manière à faciliter les imbrications (ex. `alert('<p class="fruit">plop</p>');`)
 
 ## Doctype
 
@@ -85,7 +85,7 @@ Pour IE6, IE7 et IE8, il est nécessaire de déclarer les éléments HTML5 dans 
 <![endif]-->
 ```
 
-Si Modernizr est embarqué dans la page (pour bénéficier d’un support dédié à l’amélioration progressive pour les anciens navigateurs), ce script peut déjà inclure un équivalent HTML5shiv (si on l’ajoute lors de la composition de Modernizr).
+Si [Modernizr](http://www.alsacreations.com/outils/lire/1387-modernizr.html) est embarqué dans la page (pour bénéficier d’un support dédié à l’amélioration progressive pour les anciens navigateurs), ce script peut déjà inclure un équivalent HTML5shiv (si on l’ajoute lors de la composition de Modernizr).
 
 ## Forcer le mode de compatibilité IE
 
@@ -102,7 +102,7 @@ Pour forcer IE à passer dans le mode de compatibilité standard le plus récent
 L’icône de favori est utilisée de différentes manières par les navigateurs et systèmes. Le format ICO est ancien, le format PNG permet une meilleure définition avec un poids plus léger. Mais :
 
 * IE ne reconnaît que la relation "shortcut icon" (standard : “icon”), ne reconnaît pas le format PNG, et la version 10 ne supporte plus les commentaires conditionnels (pour isoler sa déclaration non standard et le format ICO). IE (y compris 10) va tout de même chercher par défaut dans la racine `/favicon.ico`
-* Tous les autres navigateurs reconnaissent le format PNG, mais Chrome et Safari choisissent le format ICO s’il est précisé plutôt que le PNG. Opera choisit au hasard.
+* Tous les autres navigateurs reconnaissent le format PNG, mais Chrome et Safari choisissent le format ICO s’il est précisé plutôt que le PNG. Opera choisit au hasard
 
 Source : [http://realfavicongenerator.net/](http://realfavicongenerator.net/)
 
@@ -123,7 +123,7 @@ Structure satisfaisante de favicon :
 
 ## Sémantique globale
 
-Les éléments HTML5 `<header>`, `<article>`, `<main>`, `<footer>`, `<aside>`, `<section>` et `<nav>` sont privilégiés aux éléments neutres `<div>` si leur fonction s’y prête.
+Les éléments HTML5 `<header>`, `<article>`, `<main>`, `<footer>`, `<aside>`, `<section>` et `<nav>` sont privilégiés par rapport aux éléments neutres `<div>` si leur fonction s’y prête.
 
 **_Note : l’élément `<main>` n’est complètement reconnu qu’à partir de IE11_**
 
@@ -198,11 +198,11 @@ Les éléments ayant une condition ou un état particulier seront préfixés :
 
 Pour des raisons évidentes de maintenance et de lisibilité, nous limitons le nombre de classes appliquées à un élément à 4 ou 5 au grand maximum, même si nous employons un framework CSS qui nous inciterait à dépasser ce nombre.
 
-Nous éviterons de telles syntaxes : `img class="mod clearfix fl inbl w200p pas mb1 large-mb2 small-mbn"`, mais opterons plutôt pour une classe personnalisée : `img class="media"`.
+Nous éviterons de telles syntaxes : `<img class="mod clearfix fl inbl w200p pas mb1 large-mb2 small-mbn" ...`, mais opterons plutôt pour une classe personnalisée : `<img class="media" ...`.
 
 ## Liens `target="_blank"`
 
-Dans la mesure du possible, éviter les liens ouvrant une nouvelle fenêtre/onglet, sans les signaler explicitement. Ils perturbent la navigation classique du visiteur et peuvent créer des failles de sécurité.
+Dans la mesure du possible, éviter les liens ouvrant une nouvelle fenêtre/onglet sans les signaler explicitement. Ils perturbent la navigation classique du visiteur et peuvent créer des failles de sécurité.
 
 Voir aussi [https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c](https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c)
 

--- a/Guidelines-HTML.md
+++ b/Guidelines-HTML.md
@@ -4,16 +4,16 @@
 
 ## Généralités
 
-* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM).
-* Les indentations se font à l’aide de deux espaces et non à l'aide de tabulations. Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/).
-* Les liens absolus ne doivent pas faire apparaître le protocole (par exemple href="//www.alsacreations.fr/" et non href="http://www.alsacreations.fr").
-* Choisir des noms en anglais prioritairement (classes, fichiers, images, etc.).
-* Séparer les noms des fichiers, des images des classes et id CSS par des tirets (`.slide-info`, `styles-ie.css`, `jquery-2.0.min.css`, etc), sauf convention contraire apportée par le client.
+* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM),
+* Les indentations se font à l’aide de deux espaces et non à l'aide de tabulations. Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/),
+* Les liens absolus ne doivent pas faire apparaître le protocole (par exemple href="//www.alsacreations.fr/" et non href="http://www.alsacreations.fr"),
+* Choisir des noms en anglais prioritairement (classes, fichiers, images, etc.),
+* Séparer les noms des fichiers, des images des classes et id CSS par des tirets (`.slide-info`, `styles-ie.css`, `jquery-2.0.min.css`, etc), sauf convention contraire apportée par le client,
 * Les noms d'éléments et des attributs sont rédigés en minuscules,
 * Les éléments sont imbriqués correctement,
 * Les éléments sont fermés à l'aide de la balise correspondante (exception pour éléments auto-fermants HTML5 : pas de `/>`),
 * Les valeurs identiques aux attributs ne sont pas renseignées sauf nécessité (ex. en HTML5 pas de `checked="checked"`),
-* L'usage des double quotes est préconisé autour des valeurs d’attributs (ex. `class="fruit"`) ainsi que les simples quotes dans les autres langages JavaScript, PHP (ex. `alert('blup');`) de manière à faciliter les imbrications (ex. `alert('<p class="fruit">plop</p>');`)
+* L'usage des double quotes est préconisé autour des valeurs d’attributs (ex. `class="fruit"`) ainsi que les simples quotes dans les autres langages JavaScript, PHP (ex. `alert('blup');`) de manière à faciliter les imbrications (ex. `alert('<p class="fruit">plop</p>');`).
 
 ## Doctype
 
@@ -75,7 +75,7 @@ Dans le cas de modifications à opérer pour les anciennes versions d'Internet E
 
 ## HTML5shim / shiv
 
-**_Note :_ par défaut, nous ne tenons plus compte des versions Internet Explorer inférieures à IE10, donc nous n’employons plus HTML5shim._**
+**_Note :_ par défaut, nous ne tenons plus compte des versions Internet Explorer inférieures à IE10, donc nous n’employons plus HTML5shim.**
 
 Pour IE6, IE7 et IE8, il est nécessaire de déclarer les éléments HTML5 dans le DOM en JavaScript pour pouvoir les styler. [HTML5shiv](http://code.google.com/p/html5shiv/) est dédié à cet usage et affecte déjà des styles par défaut. À systématiquement placer dans la section `<head>`.
 
@@ -196,17 +196,17 @@ Les éléments ayant une condition ou un état particulier seront préfixés :
 
 ## Nombre de classes par élément
 
-Pour des raisons évidentes de maintenance et de lisibilité, nous limitons le nombre de classes appliquées à un élément à 4 ou 5 au grand maximum, même si nous employons un framework CSS qui nous inciterait dépasser ce nombre.
+Pour des raisons évidentes de maintenance et de lisibilité, nous limitons le nombre de classes appliquées à un élément à 4 ou 5 au grand maximum, même si nous employons un framework CSS qui nous inciterait à dépasser ce nombre.
 
 Nous éviterons de telles syntaxes : `img class="mod clearfix fl inbl w200p pas mb1 large-mb2 small-mbn"`, mais opterons plutôt pour une classe personnalisée : `img class="media"`.
 
-## Liens target _blank
+## Liens `target="_blank"`
 
 Dans la mesure du possible, éviter les liens ouvrant une nouvelle fenêtre/onglet, sans les signaler explicitement. Ils perturbent la navigation classique du visiteur et peuvent créer des failles de sécurité.
 
 Voir aussi [https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c](https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c)
 
-**_Toujours utiliser `rel="noopener noreferrer"` sur des liens `target="_blank"`_**
+**_Note :_ Toujours utiliser `rel="noopener noreferrer"` sur des liens `target="_blank"`**
 
 ## Meta spécifiques - SEO et réseaux sociaux
 
@@ -214,7 +214,7 @@ Les liens entre site web et les différents réseaux sociaux sont de plus en plu
 
 #### Twitter card
 
-Elle permet une présentation améliorée d’un site web sur le réseau Twitter et lien ce site web à un compte Twitter via son URL mentionnée dans un Tweet. Exemple :
+Elle permet une présentation améliorée d’un site web sur le réseau Twitter et lie ce site web à un compte Twitter via son URL mentionnée dans un Tweet. Exemple :
 
 ## ![twitter card](images/html01.png)
 
@@ -247,9 +247,9 @@ Une fois en place, il faut demander la validation par Twitter : [https://dev.twi
 
 #### Facebook et OpenGraph
 
-L’[OpenGraph](http://ogp.me/) permet, à l’instar de Twitter Cards, de maîtriser d’avantage les contenus partagés sur le réseaux social Facebook (entre autres). Le titre, l’image d’illustration, la description, l’URL, etc. peuvent être personnalisés pour ce réseaux spécifique.
+L’[OpenGraph](http://ogp.me/) permet, à l’instar de Twitter Cards, de maîtriser davantage les contenus partagés sur le réseau social Facebook (entre autres). Le titre, l’image d’illustration, la description, l’URL, etc. peuvent être personnalisés pour ce réseau spécifique.
 
-Parmi les valeurs de og: les plus utilisées on retrouve :
+Parmi les valeurs de `og:` les plus utilisées on retrouve :
 
 ```
 <meta property="og:title" content="Alsacréations, agence Web exotique">

--- a/Guidelines-JavaScript.md
+++ b/Guidelines-JavaScript.md
@@ -5,26 +5,26 @@ _Bonnes pratiques JavaScript (et jQuery) en production_
 
 ## Généralités
 
-* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM).
+* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM)
 * Valider le code avec JSHint (disponible en plugins d’éditeur de code ou gulp)
 * Les indentations se font à l’aide de deux espaces et non avec la tabulation.
-Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/).
-* JavaScript apporte une amélioration progressive, c’est-à-dire qu’il se produit une dégradation gracieuse lorsqu’il est désactivé.
-* Les scripts doivent être placés de préférence en fin de document, avant la balise `</body>` (ceci n’est plus extrêmement significatif suite aux optimisations des navigateurs mais permet d’éviter les écueils majeurs et de visualiser l’ordre de chargement au même endroit).
-* L’appel à une librairie ou à un framework (jQuery) fait toujours apparaître le numéro de version et le suffixe `-min` si le fichier a été minifié.
-* Les attributs `defer` et `async` seront utilisés à bon escient pour réduire la latence (voir [Article](http://www.alsacreations.com/astuce/lire/1562-script-attribut-async-defer.html)).
-* Utiliser "use strict"; en début de script pour activer le mode strict d’ECMAScript.
+Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/)
+* JavaScript apporte une amélioration progressive, c’est-à-dire qu’une dégradation gracieuse se produit lorsqu’il est désactivé
+* Les scripts doivent être placés de préférence en fin de document, avant la balise `</body>` (ceci n’est plus extrêmement significatif suite aux optimisations des navigateurs mais permet d’éviter les écueils majeurs et de visualiser l’ordre de chargement au même endroit)
+* L’appel à une librairie ou à un framework (jQuery) fait toujours apparaître le numéro de version et le suffixe `-min` si le fichier a été minifié
+* Les attributs `defer` et `async` seront utilisés à bon escient pour réduire la latence (voir [Article](http://www.alsacreations.com/astuce/lire/1562-script-attribut-async-defer.html))
+* Utiliser `"use strict";` en début de script pour activer le mode strict d’ECMAScript
 * Toujours utiliser le mot clé `var` pour déclarer une variable et maîtriser sa portée
 * Toujours terminer les instructions par un `;`
 * Toujours commenter (même brièvement) le code à l’aide de `//` ou `/* */`
-* Ne jamais laisser un appel à `console.log()` ou `eval()` dans le code en production.
-* Ne pas déclarer de fonctions/variables dans le scope global qui pourraient amener à des conflits avec d’autres scripts. Si besoin, utiliser une [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression).
+* Ne jamais laisser un appel à `console.log()` ou `eval()` dans le code en production
+* Ne pas déclarer de fonctions/variables dans le scope global qui pourraient amener à des conflits avec d’autres scripts. Si besoin, utiliser une [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression)
 
 Suivre les recommandations de [http://chimera.labs.oreilly.com/books/1234000000262/apa.html](http://chimera.labs.oreilly.com/books/1234000000262/apa.html)
 
 ## Déclaration et variables
 
-Utiliser les structures littérales simple pour déclarer tableaux et objets.
+Utiliser les structures littérales simples pour déclarer tableaux et objets.
 
 ```
 var montableau = [1,2,3];
@@ -76,9 +76,9 @@ var monprojet = {
 
 De préférence :
 
-* Nommer les fonctions/plugins d’après les classes HTML avec lesquelles elles vont interagir.
-* Les préfixer par un code relatif au nom du projet.
-* Placer les accolades sur la première ligne de bloc et non sur la suivante pour éviter due à l’insertion implicite de `;` pour terminer les lignes.
+* Nommer les fonctions/plugins d’après les classes HTML avec lesquelles elles vont interagir
+* Les préfixer par un code relatif au nom du projet
+* Placer les accolades sur la première ligne de bloc et non sur la suivante pour éviter due à l’insertion implicite de `;` pour terminer les lignes
 
 ```
 if (quelquechose) {
@@ -90,7 +90,7 @@ if (quelquechose) {
 
 ## Chaînes de texte
 
-Utiliser les simples quotes `'` pour conserver une consistance et faciliter l’écriture du HTML.
+Utiliser les simples quotes `'` pour conserver une cohérence et faciliter l’écriture du HTML.
 
 ```
 var msg = 'Ceci est un message';
@@ -173,7 +173,7 @@ charset = utf-8
 var $el = $('#el');
 ```
 
-* Encapsuler les développements jQuery tant que possible dans des plugins, ce n’est pas compliqué, idéalement avec le *boilerplate*.
+* Encapsuler les développements jQuery tant que possible dans des plugins, ce n’est pas compliqué, idéalement avec le *boilerplate*
 
 * Démarrer avec cette syntaxe pour document ready :
 
@@ -185,18 +185,18 @@ jQuery(document).ready(function($) {
 
 ### Plugin boilerplate
 
-Modèle relativement simple de plugin-type, avec options par défaut, remplacées/complétées par les paramètres `data-*` en HTML, méthodes privées et publiques. Voir aussi sur le dépôt Github [https://github.com/alsacreations/pepin/blob/master/plugin.js](https://github.com/alsacreations/pepin/blob/master/plugin.js)
+Modèle relativement simple de plugin-type, avec options par défaut, remplacées/complétées par les paramètres `data-*` en HTML, méthodes privées et publiques. Voir aussi sur le dépôt GitHub [https://github.com/alsacreations/pepin/blob/master/plugin.js](https://github.com/alsacreations/pepin/blob/master/plugin.js)
 
-* Simplifier au maximum le code en découpant par actions simples.
-* Utiliser au maximum le document "statique" HTML, dont les attributs `data-*`, les classes, ou l’ordre des éléments pour construire un script autour, plutôt que de se reposer uniquement sur JS ou des variables. Placer les attributs `data-*` sur les éléments pour lesquels ils seront utiles, notamment le conteneur du plugin
-* Différencier classes qui vont permettre de styler l’élément (dans les fichiers CSS) et classes qui vont permettre d’activer un comportement spécifique JS sur l’élément (fichiers JS) en les préfixant par `js-`.
+* Simplifier au maximum le code en découpant par actions simples
+* Utiliser au maximum le document "statique" HTML, dont les attributs `data-*`, les classes ou l’ordre des éléments pour construire un script autour, plutôt que de se reposer uniquement sur JS ou des variables. Placer les attributs `data-*` sur les éléments pour lesquels ils seront utiles, notamment le conteneur du plugin
+* Différencier classes qui vont permettre de styler l’élément (dans les fichiers CSS) et classes qui vont permettre d’activer un comportement spécifique JS sur l’élément (fichiers JS) en les préfixant par `js-`
 
 ```
 <div class="slideshow js-slideshow" data-timing="2000" ...>
    <figure class="slideshow-item">
 ```
 
-* Utiliser les classes CSS du projet pour cacher/masquer des éléments, lancer des transitions, ou changer leur état
+* Utiliser les classes CSS du projet pour cacher/masquer des éléments, lancer des transitions ou changer leur état
 
 ```
 $('element').addClass('visually-hidden');
@@ -208,10 +208,10 @@ plutôt que
 $('element').hide();
 ```
 
-* De même pour les animations/transitions, il est souvent préférable de passer par l’ajout/suppression de classes CSS.
-* Se reposer sur les éléments pouvant recevoir le focus (`<a>`, `<button>`, `<input>`) pour l’ajout d’événements `onclick`, etc.
-* Ne pas hésiter à utiliser des plugins éprouvés (toujours tester s’ils peuvent être multiples sur une même page).
-* Penser à prévoir les cas de figure où le code peut être appelé plusieurs fois dans une même page, ou plusieurs fois par erreur sur un même élément (par exemple avec la gestion on/off des événements, les attributs `data-*` pour savoir s’il a déjà été appliqués, etc).
+* De même pour les animations/transitions, il est souvent préférable de passer par l’ajout/suppression de classes CSS
+* Se reposer sur les éléments pouvant recevoir le focus (`<a>`, `<button>`, `<input>`) pour l’ajout d’événements `onclick`, etc
+* Ne pas hésiter à utiliser des plugins éprouvés (toujours tester s’ils peuvent être multiples sur une même page)
+* Penser à prévoir les cas de figure où le code peut être appelé plusieurs fois dans une même page ou plusieurs fois par erreur sur un même élément (par exemple avec la gestion on/off des événements, les attributs `data-*` pour savoir s’il a déjà été appliqués, etc)
 * Penser à prévoir les cas de figure où :
   * le fichier peut être rechargé dans la même page
   * le code doit pouvoir être rappelé sur le même élément sans provoquer de bugs notamment au niveau des styles modifiés, des événements ajoutés (penser à off/on)

--- a/Guidelines-Workflow.md
+++ b/Guidelines-Workflow.md
@@ -1,20 +1,20 @@
-# Guidelines : WorkFlow
+# Guidelines : Workflow
 
-_Quelques bonnes pratiques pour un WorkFlow de production_
+_Quelques bonnes pratiques pour un Workflow de production_
 
 ## Généralités
 
-* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM).
+* L’encodage des fichiers et des bases de données doit se faire en UTF-8 (sans BOM)
 * Les indentations se font à l’aide de deux espaces et non sous forme de tabulations.
-Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/).
+Pour assurer une cohérence inter-projets, utiliser la convention [EditorConfig](http://editorconfig.org/)
 
 ## Organisation globale et outils
 
 ### Git
 
-Tous les projets sont versionnés sur Git.
+Tous les projets sont versionnés avec Git.
 
-La notation des versions (tags) sera sous la forme : version majeure . version mineure . correctifs mineurs. Exemple: `v1.3.37`
+La notation des versions (tags) sera sous la forme : version majeure . version mineure . correctifs mineurs (Semantic Versioning ou [semver](http://semver.org)). Exemple: `v1.3.37`
 
 ### Dépendances
 
@@ -45,7 +45,7 @@ Voici la liste des éditeurs de code communément adoptés :
 * concaténation tous types (gulp-concat)
 * renommage (gulp-rename)
 * sourcemaps (gulp-sourcemaps)
-* autoprefixer (gulp-autoprefixer)
+* Autoprefixer (gulp-autoprefixer)
 * compression des images (avec imagemin, pour jpeg, png, svg)
 * En bonus : browser-sync
 
@@ -73,7 +73,7 @@ Il est prévu pour fonctionner automatiquement avec les outils suivants :
 
 ### EditorConfig
 
-Afin d’assurer une consistance entre notre éditeur HTML et notre convention d’espaces / tabulations pour chaque projet :
+Afin d’assurer une cohérence entre notre éditeur HTML et notre convention d’espaces / tabulations pour chaque projet :
 
 * Installer le [plugin EditorConfig](http://editorconfig.org/#download) correspondant à notre éditeur
 * Ajouter un fichier [.editorconfig](http://editorconfig.org/) à la racine du projet, dont le contenu sera :
@@ -94,7 +94,7 @@ Les outils ci-après sont contenus dans le prototype de nouveau projet [Bretzel]
 
 ## Préprocesseurs
 
-L’emploi de surcouches préprocesseurs (LESS, Sass, Stylus), destinées à automatiser certaines tâches pourra être justifié selon les projets et les besoins du clients. Il ne sera cependant pas systématique, chacun de nos intégrateurs ayant suffisamment de compétences pour disposer d’outils annexes.
+L’emploi de surcouches préprocesseurs (LESS, Sass, Stylus), destinées à automatiser certaines tâches pourra être justifié selon les projets et les besoins du client. Il ne sera cependant pas systématique, chacun de nos intégrateur·trice·s ayant suffisamment de compétences pour disposer d’outils annexes.
 
 Si le choix d’un préprocesseur est justifié, nous opterons par défaut pour **Sass** plutôt que LESS.
 
@@ -136,12 +136,12 @@ Ne pas utiliser la ligne de commande locale sur le partage de fichiers distant
 
 La configuration de Gulp se trouve au sein des fichiers :
 
-* `package.json` (liste des plugins : minify, autoprefixer, Sass, etc.)
+* `package.json` (liste des plugins : minify, Autoprefixer, Sass, etc.)
 * `gulpfile.js` (liste des tâches)
 
 #### Commandes
 
-* `gulp` (équivalent à gulp default, qui est lié aux tâches suivantes communes)
+* `gulp` (équivalent à `gulp default`, qui est lié aux tâches suivantes communes)
 * `gulp styles` : génération des styles à partir des pré-processeurs
 * `gulp scripts` : génération des scripts
 * `gulp watch` : exécution des tâches communes précédentes lorsqu’un fichier change


### PR DESCRIPTION
* Soucis avec l'italique et le gras dans le code MarkDown 
* Des typos, majuscules, virgules, etc
* s/consistant/cohérent (franglais)
* s/repo/dépôt
* Listes à puce : ni virgule, ni point à la fin de chaque item et cohérent partout (comme dans le dernier commit de Rodolphe)
* Ajout de liens vers Normalize, Modernizr, semver
* exemples de code cohérents avec nos conventions (`target="_blank"` avec guillemets par ex.)
* NDD sans `/` à la fin (j'aime po)
* on versionne _avec_ Git _sur_ Gitlab (pas sur Git)
