### PR TITLE
[docs resources/links] Suppression lien mort redpen.io et ajout d'un testeur et visualisateur d'expressions régulière

### DIFF
--- a/resources/links.md
+++ b/resources/links.md
@@ -379,7 +379,6 @@ Maquettes / story-boards / wireframes / mockups / zoning
 - <https://www.draw.io/>
 - <https://www.invisionapp.com/>
 - <https://bounceapp.com/>
-- <https://redpen.io/>
 - <https://uigenerator.org/> Générer des mockups PNG d'interfaces (desktop/mobile)
 
 ### Ardoises en ligne
@@ -699,6 +698,7 @@ Maquettes / story-boards / wireframes / mockups / zoning
 - <https://regex101.com/> Tester les regexp en live
 - <https://extendsclass.com/regex-tester.html> Tester les regexp en live
 - <https://ihateregex.io/> Visualiser les regexp en live
+- <https://phphub.net/regex/> Tester et visualiser les regexp en live
 
 ---
 


### PR DESCRIPTION
Bonjour, j'ai supprimé le lien vers redpen.io (Ressource plus disponible), et ajouté phphub.net/regex/ (Je suis le créateur du site), un testeur et visualisateur d'expression régulière.